### PR TITLE
Make the scripts runnable outside of Travis

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,4 @@
-
-ARG FIRMWARE_PATH
+FROM particle/firmware-buildpack-builder
 ENV FIRMWARE_REPO=not-used
 WORKDIR /
-COPY bin /bin
-COPY ${FIRMWARE_PATH} /firmware
+COPY . /firmware

--- a/README.md
+++ b/README.md
@@ -10,7 +10,37 @@ This repo is used by [`firmware` Travis CI build](https://travis-ci.org/spark/fi
 | [HAL](https://github.com/particle-iot/buildpack-hal) / [Legacy](https://github.com/particle-iot/buildpack-0.3.x)   |
 | [Base](https://github.com/particle-iot/buildpack-base) |
 
-## Flow
+## Running scripts locally when developing a buildpack
+
+First clone and set up this repo:
+```
+$ git clone git@github.com:particle-iot/firmware-buildpack-builder.git
+$ cd firmware-buildpack-builder
+$ export FIRMWARE_PATH=path/to/particle/firmware
+$ export DOCKER_IMAGE_NAME=particle/your-firmware-name
+```
+
+### To build a firmware buildpack (containing just toolchain + firmware) run:
+```
+$ script/build-image
+```
+**Note:** the firmware buildpack inherits `BUILDPACK_VARIATION` image specified in `.buildpackrc` file in your firmware. If you need to use different toolchain it is recommended to create a different variation and specify it in the `.buildpackrc` file.
+
+### To build a buildpack with precompiled intermediate files for a platform used by the cloud compiler (same as firmware buildpack + it runs `make` in all important dirs)
+
+First empty the `RELEASE_PLATFORMS` array in `.buildpackrc` and then add your platform to `PRERELEASE_PLATFORMS`. Then run:
+
+```
+$ script/build-platform-images
+```
+
+Once the images are built you can test them with:
+
+```
+$ docker run --rm -it -v EXAMPLE_APP_DIRECTORY:/input -e PLATFORM_ID=EXAMPLE_PLATFORM_ID $DOCKER_IMAGE_NAME
+```
+
+## Flow inside Travis CI
 
 When doing a Travis CI job following scripts should be executed in order:
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ $ git clone git@github.com:particle-iot/firmware-buildpack-builder.git
 $ cd firmware-buildpack-builder
 $ export FIRMWARE_PATH=path/to/particle/firmware
 $ export DOCKER_IMAGE_NAME=particle/your-firmware-name
+$ export TAG=a.b.c-rc.X
 ```
 
 ### To build a firmware buildpack (containing just toolchain + firmware) run:
 ```
-$ script/build-image
+$ scripts/build-image
 ```
 **Note:** the firmware buildpack inherits `BUILDPACK_VARIATION` image specified in `.buildpackrc` file in your firmware. If you need to use different toolchain it is recommended to create a different variation and specify it in the `.buildpackrc` file.
 
@@ -31,7 +32,7 @@ $ script/build-image
 First empty the `RELEASE_PLATFORMS` array in `.buildpackrc` and then add your platform to `PRERELEASE_PLATFORMS`. Then run:
 
 ```
-$ script/build-platform-images
+$ scripts/build-platform-images
 ```
 
 Once the images are built you can test them with:

--- a/scripts/build-firmware-image
+++ b/scripts/build-firmware-image
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Builds the image containing the firmware repo and a second one with test
+# dependencies installed
+
+# Exit on errors
+set -e
+
+tmpfile=$(mktemp /tmp/dockerfile.XXXXXX)
+
+# Create the base image with bin scripts
+echo "FROM ${BUILDPACK_BASE}:${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}" > $tmpfile
+echo "COPY bin /bin" >> $tmpfile
+docker build -t particle/firmware-buildpack-builder -f $tmpfile .
+echo
+
+# Create main Dockerfile
+tmpfile=$(mktemp /tmp/dockerfile.XXXXXX)
+cat Dockerfile.template > $tmpfile
+# Build main image
+printf "${GREEN}Building main image based on${NC} "
+printf "${YELLOW}${BUILDPACK_BASE}:${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}${NC}...\n"
+docker build -t $DOCKER_IMAGE_NAME -f $tmpfile $FIRMWARE_PATH
+echo
+
+# Create test Dockerfile
+echo "FROM ${DOCKER_IMAGE_NAME}" > $tmpfile
+cat Dockerfile.test.template >> $tmpfile
+# Build test image
+printf "${GREEN}Building test image${NC}...\n"
+docker build -f $tmpfile \
+	-t $DOCKER_IMAGE_NAME-test .
+rm $tmpfile
+echo
+echo
+
+printf "✨💫 ${GREEN}Built following images:${NC}\n"
+printf "👉 ${YELLOW}particle/firmware-buildpack-builder${NC} - just buildpack base + bin directory from this repo\n"
+printf "👉 ${YELLOW}$DOCKER_IMAGE_NAME${NC} - above + firmware from \$FIRMWARE_PATH\n"
+printf "👉 ${YELLOW}$DOCKER_IMAGE_NAME-test${NC} - above + gcc used for running unit tests\n"

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -1,5 +1,9 @@
-#!/bin/bash
-FIRMWARE_PATH=`pwd`
+#!/usr/bin/env bash
+
+if [[ -z $FIRMWARE_PATH ]]; then
+	FIRMWARE_PATH=`pwd`
+fi
+
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 # Read the defaults
 source scripts/constants
@@ -12,20 +16,4 @@ fi
 # Read firmware build configuration
 source $FIRMWARE_PATH/.buildpackrc
 
-# Create main Dockerfile
-echo "FROM ${BUILDPACK_BASE}:${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}" > Dockerfile
-cat Dockerfile.template >> Dockerfile
-# Build main image
-printf "${GREEN}Building main image based on${NC} "
-printf "${YELLOW}${BUILDPACK_BASE}:${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}${NC}...\n"
-docker build -t $DOCKER_IMAGE_NAME --build-arg FIRMWARE_PATH=`basename $FIRMWARE_PATH` .
-echo
-
-# Create test Dockerfile
-echo "FROM ${DOCKER_IMAGE_NAME}" > Dockerfile.test
-cat Dockerfile.test.template >> Dockerfile.test
-# Build test image
-printf "${GREEN}Building test image${NC}...\n"
-docker build -f Dockerfile.test \
-	-t $DOCKER_IMAGE_NAME-test .
-echo
+source scripts/build-firmware-image

--- a/scripts/build-platform-images
+++ b/scripts/build-platform-images
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Builds separate image for each platform by precompiling firmware for
+# each target
+
+# Exit on errors
+set -e
+
+source scripts/constants
+source scripts/functions
+
+# Read firmware build configuration
+source $FIRMWARE_PATH/.buildpackrc
+
+# Prebuild releases
+for platform in "${RELEASE_PLATFORMS[@]}"
+do
+	prebuild-platform $platform
+done
+
+# Prebuild prereleases
+for platform in "${PRERELEASE_PLATFORMS[@]}"
+do
+	prebuild-platform $platform
+done

--- a/scripts/constants
+++ b/scripts/constants
@@ -7,3 +7,7 @@ NC='\033[0m'
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
 BUILDPACK_VERSION=0.0.13
+
+if [[ -z $FIRMWARE_PATH ]]; then
+	FIRMWARE_PATH=`pwd`
+fi

--- a/scripts/functions
+++ b/scripts/functions
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+function prebuild-platform {
+	PLATFORM=$1
+
+	printf "${GREEN}Prebuilding platform${NC} "
+	printf "${YELLOW}${PLATFORM}${NC}...\n"
+	# Check if this platform requires different buildpack variation
+	VARIATION="BUILDPACK_VARIATION_PLATFORM_${PLATFORM^^}"
+	if [ -z ${!VARIATION} ]; then
+		BUILDPACK_TAG="${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}"
+	else
+		BUILDPACK_TAG="${BUILDPACK_VERSION}-${!VARIATION}"
+		printf "   ${YELLOW}Custom buildpack variation:${NC} ${BUILDPACK_TAG}\n"
+	fi
+
+	# Check if platform requires modules to be prebuild
+	MODULAR=n
+	for modular_platform in "${MODULAR_PLATFORMS[@]}"
+	do
+		if [ $PLATFORM == $modular_platform ]; then
+			MODULAR=y
+		fi
+	done
+
+	tmpfile=$(mktemp /tmp/dockerfile.XXXXXX)
+
+	# Create Dockerfile
+	echo "FROM ${BUILDPACK_BASE}:${BUILDPACK_TAG}" > $tmpfile
+	echo "COPY bin /bin" >> $tmpfile
+	docker build -t particle/firmware-buildpack-builder -f $tmpfile .
+
+	cat Dockerfile.template > $tmpfile
+	cat Dockerfile.platform.template >> $tmpfile
+
+	printf "${GREEN}Building for${NC} "
+	printf "${PLATFORM}${NC}...\n"
+	docker build -f $tmpfile \
+		--build-arg PLATFORM=$PLATFORM \
+		--build-arg MODULAR=$MODULAR \
+		-t $DOCKER_IMAGE_NAME $FIRMWARE_PATH
+	if [ $? -eq 0 ]; then
+		printf "${GREEN}Tagging${NC} "
+		printf "${YELLOW}${DOCKER_IMAGE_NAME}:${TAG}-${PLATFORM}${NC}...\n"
+		docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TAG-$PLATFORM
+		docker push $DOCKER_IMAGE_NAME:$TAG-$PLATFORM
+	fi
+	rm $tmpfile
+	echo
+}

--- a/scripts/push-image
+++ b/scripts/push-image
@@ -1,79 +1,23 @@
-#!/bin/bash
-FIRMWARE_PATH=`pwd`
+#!/usr/bin/env bash
+
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 # Read the defaults
 source scripts/constants
 
-# Read firmware build configuration
-source $FIRMWARE_PATH/.buildpackrc
-
 # If git tag is being build, tag the Docker image too
-if [ ! -z "$TRAVIS_TAG" ]; then
+if [[ ! -z "$TRAVIS_TAG" ]]; then
 	TAG=${TRAVIS_TAG#"v"}
-	docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TAG
 else
-	TAG=latest
+	TAG=`cd $FIRMWARE_PATH && git rev-parse --short HEAD`
 fi
+docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TAG
+
 printf "${GREEN}Tagging main image as${NC} "
 printf "${YELLOW}${DOCKER_IMAGE_NAME}:${TAG}${NC}...\n"
 docker push $DOCKER_IMAGE_NAME:$TAG
 echo
 
-function prebuild-platform {
-	PLATFORM=$1
-
-	printf "${GREEN}Prebuilding platform${NC} "
-	printf "${YELLOW}${PLATFORM}${NC}...\n"
-	# Check if this platform requires different buildpack variation
-	VARIATION="BUILDPACK_VARIATION_PLATFORM_${PLATFORM^^}"
-	if [ -z ${!VARIATION} ]; then
-		BUILDPACK_TAG="${BUILDPACK_VERSION}-${BUILDPACK_VARIATION}"
-	else
-		BUILDPACK_TAG="${BUILDPACK_VERSION}-${!VARIATION}"
-		printf "   ${YELLOW}Custom buildpack variation:${NC} ${BUILDPACK_TAG}\n"
-	fi
-
-	# Check if platform requires modules to be prebuild
-	MODULAR=n
-	for modular_platform in "${MODULAR_PLATFORMS[@]}"
-	do
-		if [ $PLATFORM == $modular_platform ]; then
-			MODULAR=y
-		fi
-	done
-
-	# Create Dockerfile
-	echo "FROM ${BUILDPACK_BASE}:${BUILDPACK_TAG}" > Dockerfile.platform
-	cat Dockerfile.template >> Dockerfile.platform
-	cat Dockerfile.platform.template >> Dockerfile.platform
-
-	printf "${GREEN}Building for${NC} "
-	printf "${PLATFORM}${NC}...\n"
-	docker build -f Dockerfile.platform \
-		--build-arg PLATFORM=$PLATFORM \
-		--build-arg MODULAR=$MODULAR \
-		--build-arg FIRMWARE_PATH=`basename $FIRMWARE_PATH` \
-		-t $DOCKER_IMAGE_NAME .
-	if [ $? -eq 0 ]; then
-		printf "${GREEN}Tagging${NC} "
-		printf "${YELLOW}${DOCKER_IMAGE_NAME}:${TAG}-${PLATFORM}${NC}...\n"
-		docker tag $DOCKER_IMAGE_NAME:latest $DOCKER_IMAGE_NAME:$TAG-$PLATFORM
-		docker push $DOCKER_IMAGE_NAME:$TAG-$PLATFORM
-	fi
-	echo
-}
-
 # Prebuild images for platforms
 if [ ! -z "$TRAVIS_TAG" ]; then
-	# Prebuild releases
-	for platform in "${RELEASE_PLATFORMS[@]}"
-	do
-		prebuild-platform $platform
-	done
-
-	# Prebuild prereleases
-	for platform in "${PRERELEASE_PLATFORMS[@]}"
-	do
-		prebuild-platform $platform
-	done
+	source scripts/build-platform-images
 fi

--- a/scripts/run-tests-in-container
+++ b/scripts/run-tests-in-container
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 # Read the defaults
 source scripts/constants


### PR DESCRIPTION
The updated readme shows how to use the scripts.

Merging it in will have immediate effect with Travis (nothing should break but has to be tested) so for now NPD team can use this branch to work on.