### PR TITLE
GCC9 support and zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN /bin/prebuild-platform
 # Test image adding on things required for running the unit tests
 FROM ${DOCKER_IMAGE_NAME}:${MAIN_VERSION} as test
 RUN sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
-  && apt-get update -q && apt-get install -qy wget gcc-4.9 g++-4.9 parallel \
+  && apt-get update -q && apt-get install -qy wget gcc-4.9 g++-4.9 parallel zlib1g-dev \
   && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 60 \
   && apt-get clean && apt-get purge \

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=0.0.16
+BUILDPACK_VERSION=0.0.17
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`


### PR DESCRIPTION
### Description

Bumps buildpack-hal version to 0.0.17 (particle-iot/buildpack-hal#11 which adds support for gcc 9) and adds zlib headers to test image to enable unit tests for compressed binaries in DeviceOS (https://github.com/particle-iot/device-os/pull/2097).

DeviceOS CI build with this branch has passed: https://travis-ci.org/github/particle-iot/device-os/builds/687124304, https://github.com/particle-iot/device-os/commit/6c0450b9a6d33639b4fd75a25dc65b64378b9d86

### References

- https://app.clubhouse.io/particle/story/54654/create-buildpack-for-gcc-9