### PR TITLE
Bump buildpack-hal version to 0.0.18

### DIFF
--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=0.0.17
+BUILDPACK_VERSION=0.0.18
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`


### PR DESCRIPTION
buildpack-hal 0.0.18 has a variation that uses the toolchain based on ARM GCC 10, see https://github.com/particle-iot/buildpack-hal/pull/12.