### PR TITLE
feature/ch76129/use-toolchain-manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,25 @@ COPY bin /bin
 FROM ${DEVICEOS_BASE_IMAGE}:${DEVICEOS_VERSION} as deviceos
 WORKDIR /
 
-# Base image
-FROM ${BUILDPACK_BASE}:${BUILDPACK_BASE_VERSION} as builder
+# Main image combining base image, toolchain, and DeviceOS sources
+# Some sensible default
+FROM ${DOCKER_IMAGE_NAME}:${BASE_VERSION} as main
+ENV FIRMWARE_REPO=not-used
+WORKDIR /
+COPY --from=deviceos / /firmware/
 
+# This could be a separate step, but for now to simplify CI updates
+# This is integrated into the main step
 RUN \
+  sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
   apt-get update -q \
-  && apt-get install -qy wget vim-common parallel libarchive-zip-perl \
+  && apt-get install -qy wget parallel libarchive-zip-perl \
   && curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh \
   && apt-get clean \
   && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && cat /etc/*release
 
-COPY --from=deviceos / /firmware/
 ENV PATH="/root/.particle/bin":$PATH
 RUN \
   prtcl toolchain:install source:/firmware \
@@ -36,16 +42,6 @@ RUN \
   && ls -la /root/.particle \
   && ls -la /root/.particle/toolchains \
   && ls -la /root/.particle/bin
-
-# Main image combining base image, toolchain, and DeviceOS sources
-# Some sensible default
-FROM ${DOCKER_IMAGE_NAME}:${BASE_VERSION} as main
-ENV FIRMWARE_REPO=not-used
-WORKDIR /
-COPY --from=deviceos / /firmware/
-COPY --from=builder /root/.particle /root/.particle
-ENV PATH="/root/.particle/bin":$PATH
-
 
 # Platform image, prebuilding the modules required for building the application
 FROM ${DOCKER_IMAGE_NAME}:${MAIN_VERSION} as platform
@@ -57,8 +53,7 @@ RUN /bin/prebuild-platform
 
 # Test image adding on things required for running the unit tests
 FROM ${DOCKER_IMAGE_NAME}:${MAIN_VERSION} as test
-RUN sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
-  && apt-get update -q && apt-get install -qy wget gcc-4.9 g++-4.9 parallel zlib1g-dev \
+RUN apt-get update -q && apt-get install -qy gcc-4.9 g++-4.9 zlib1g-dev \
   && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 \
   && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 60 \
   && apt-get clean && apt-get purge \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,20 +22,15 @@ WORKDIR /
 COPY --from=deviceos / /firmware/
 
 # This could be a separate step, but for now to simplify CI updates
-# This is integrated into the main step
+# this is integrated into the main step
+ENV PATH="/root/.particle/bin":$PATH
 RUN \
-  sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
-  apt-get update -q \
-  && apt-get install -qy wget parallel libarchive-zip-perl \
-  && curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh \
+  curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh \
   && apt-get clean \
   && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-  && cat /etc/*release
-
-ENV PATH="/root/.particle/bin":$PATH
-RUN \
-  prtcl toolchain:install source:/firmware \
+  && cat /etc/*release \
+  && prtcl toolchain:install source:/firmware \
   && prtcl toolchain:use source:/firmware \
   && echo ":::: Using $(which arm-none-eabi-gcc)" \
   && echo ":::: With directories and files" \

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=0.0.18
+BUILDPACK_VERSION=0.2.0
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`


### PR DESCRIPTION
https://app.clubhouse.io/particle/story/76129/update-firmware-buildpack-builder-to-use-workbench-bundles

This is a first-pass at getting the Device OS' CI / CD processes on the same compiler dependencies used by the local compiler we ship with Particle Workbench, etc. Dependencies are installed via CLI vNext (aka `prtcl`, see [1](https://github.com/particle-iot/cli/tree/main/packages/cli#prtcl-toolchaininstall-firmwareversion-targetplatform), [2](https://github.com/particle-iot/cli/tree/main/packages/cli#prtcl-toolchainuse-firmwareversion-targetplatform)) which uses the bundles managed by the `@particle/toolchain-manager` lib ([source](https://github.com/particle-iot/cli/tree/main/packages/toolchain-manager)).

We weren't entirely clear on how to test or otherwise vet these changes but running the following seemed to show success:

```sh
export FIRMWARE_PATH=tmp/device-os
export DOCKER_IMAGE_NAME=particle/test-toolchain-build
export TAG=3.0.0-rc.0
scripts/build-deviceos
scripts/build-image
scripts/build-platform-images
```

(save the above as `test-toolchain-build.sh`, make executable, and run)

...running the following docker command:

```
PLATFORM=tracker docker run --rm -it -v /Users/me/code/my-app:/input -e PLATFORM_ID=26 -v ${PWD}:/output particle/test-toolchain-build:3.0.0-rc.0-tracker
```

...produced a `firmware.bin` which when inspected (`particle binary inspect`), showed:


```
firmware.bin
 CRC is ok (e7a59703)
 Compiled for tracker
 This is an application module number 1 at version 6
 It depends on a system module number 1 at version 3005
```

Next-step is to get feedback from Device OS maintainers and perhaps pair on fixes and improvements.

