### PR TITLE
Update base/hal image to ubuntu 20.04 for GCC 11 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,3 +65,14 @@ RUN apt-get update -qy \
   && gcc --version \
   && g++ --version
 
+SHELL ["/bin/bash", "--login", "-i", "-c"]
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=12
+RUN mkdir -p $NVM_DIR
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash \
+  && source /root/.bashrc \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default
+SHELL ["/bin/bash", "--login", "-c"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update -qy \
 SHELL ["/bin/bash", "--login", "-i", "-c"]
 ENV NVM_DIR=/usr/local/nvm
 ENV NODE_VERSION=12
-RUN mkdir -p $NVM_DIR
+RUN mkdir -p $NVM_DIR \
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash \
   && source /root/.bashrc \
   && nvm install $NODE_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG MAIN_VERSION
 
 # Base image, based on a buildpack with binaries from this repo
 FROM ${BUILDPACK_BASE}:${BUILDPACK_BASE_VERSION} as base
-COPY bin /bin
+COPY bin /usr/bin
 
 # DeviceOS image, containing just the DeviceOS sources
 FROM ${DEVICEOS_BASE_IMAGE}:${DEVICEOS_VERSION} as deviceos

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,17 @@ RUN apt-get update -qy \
   && apt-get install -qy software-properties-common \
   && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
   && apt-get update -qy \
-  && apt-get install gcc-11 g++-11 -qy \
-  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 \
+  && apt-get install gcc g++ gcc-11 g++-11 -qy \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 1100 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
                          --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
                          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
                          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 \
-  && update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 110 \
+  && update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 1100 \
+  && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 1100 \
+  && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 1100 \
+  && update-alternatives --set cc /usr/bin/gcc \
+  && update-alternatives --set c++ /usr/bin/g++ \
   && add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y \
   && apt-get clean && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,20 @@ RUN /bin/prebuild-platform
 
 # Test image adding on things required for running the unit tests
 FROM ${DOCKER_IMAGE_NAME}:${MAIN_VERSION} as test
-RUN apt-get update -q && apt-get install -qy gcc-4.9 g++-4.9 zlib1g-dev \
-  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 \
-  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 60 \
+RUN apt-get update -qy \
+  && apt-get install -qy software-properties-common \
+  && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
+  && apt-get update -qy \
+  && apt-get install gcc-11 g++-11 -qy \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
+                         --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
+                         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 \
+                         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 \
+  && update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 110 \
+  && add-apt-repository --remove ppa:ubuntu-toolchain-r/test -y \
   && apt-get clean && apt-get purge \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && gcc --version \
+  && g++ --version
+

--- a/scripts/ci
+++ b/scripts/ci
@@ -48,4 +48,10 @@ fi
 
 printf "${GREEN}Running tests inside of container $DOCKER_IMAGE_NAME:$TEST_IMAGE_VERSION...${NC}\n"
 
-docker run --rm $EXTRA_ARG -w /firmware --env BUILD_PLATFORM="${BUILD_PLATFORM[*]}" $DOCKER_IMAGE_NAME:$TEST_IMAGE_VERSION /bin/run-tests
+if [ -z $BUILDPACK_NORM ]; then
+    RMARG="--rm"
+else
+    RMARG=""
+fi
+
+docker run $RMARG $EXTRA_ARG -w /firmware --env BUILD_PLATFORM="${BUILD_PLATFORM[*]}" $DOCKER_IMAGE_NAME:$TEST_IMAGE_VERSION /bin/run-tests

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=0.3.0
+BUILDPACK_VERSION=feature-update-base-to-20.04-and-gcc-11-9485708
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=feature-update-base-to-20.04-and-gcc-11-6131720
+BUILDPACK_VERSION=0.3.0
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=0.2.0
+BUILDPACK_VERSION=0.3.0
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`

--- a/scripts/constants
+++ b/scripts/constants
@@ -38,7 +38,7 @@ fi
 GIT_ORIGIN=$(cd $FIRMWARE_PATH && git config --get remote.origin.url | cut -d ":" -f 2)
 
 if [[ ! $(echo "$GIT_ORIGIN" | grep 'particle-iot/') ]]; then
-   PARTICLE_ORIGIN=1
+   PARTICLE_ORIGIN=${PARTICLE_ORIGIN:-1}
 else
-   PARTICLE_ORIGIN=0
+   PARTICLE_ORIGIN=${PARTICLE_ORIGIN:-0}
 fi

--- a/scripts/constants
+++ b/scripts/constants
@@ -14,7 +14,7 @@ DEVICEOS_BASE_IMAGE=particle/device-os
 
 # Default base buildpack name and version
 BUILDPACK_BASE=particle/buildpack-hal
-BUILDPACK_VERSION=feature-update-base-to-20.04-and-gcc-11-9485708
+BUILDPACK_VERSION=feature-update-base-to-20.04-and-gcc-11-6131720
 
 if [[ -z $FIRMWARE_PATH ]]; then
 	FIRMWARE_PATH=`pwd`


### PR DESCRIPTION
We are using ARM GCC 10 for building Device OS and are migrating to C++17 standard. This will require an update to the host compiler for building unit tests and GCC (virtual) platform.

This PR updates the base/hal image to use Ubuntu 20.04, which does support installation of GCC 11 out of the box-ish (ubuntu-toolchain-r/test ppa).

https://github.com/particle-iot/buildpack-base/pull/8
https://github.com/particle-iot/buildpack-hal/pull/14