### PR TITLE
chore/prtcl-toolchain-install-quiet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ COPY --from=deviceos / /firmware/
 # this is integrated into the main step
 ENV PATH="/root/.particle/bin":$PATH
 RUN \
-  curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh \
+  printf 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "5";\n' | sudo tee /etc/apt/apt.conf.d/99timeout > /dev/null \
+  && curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh \
   && apt-get clean \
   && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN \
   && apt-get purge \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && cat /etc/*release \
-  && prtcl toolchain:install source:/firmware \
+  && prtcl toolchain:install source:/firmware --quiet \
   && prtcl toolchain:use source:/firmware \
   && echo ":::: Using $(which arm-none-eabi-gcc)" \
   && echo ":::: With directories and files" \


### PR DESCRIPTION
a few minor tweaks to output less logs during toolchain installs and make `apt-get` more reliable in the face of timeouts and other network weirdness.

also see:
https://github.com/particle-iot/device-os/pull/2444
https://github.com/particle-iot/device-os/blob/72a06157e3fbf8ec9c2c769a8f46cada52d2991e/scripts/test-build-tasks.sh#L66
https://app.circleci.com/pipelines/github/particle-iot/device-os/670/workflows/d60b007a-0f2e-48b7-99da-cc99655684f9